### PR TITLE
Add zoom level asterisk, erase cached data feedback and fix symlink bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The specific changes in this forked version:
 * Code changes to enable using [PyInstaller](https://pyinstaller.org/en/stable/) to bundle Ortho4XP and its dependencies into a single package.
 * Add the ability to set an alternate `custom_overlay_src` directory to resolve an issue for some users. The default X-Plane scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` and `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found if its a location where the .dsf files are located in the second directory.
 * Saves custom_dem and fill_nodata to global configuration.
-* Display asterik next to zoom level number in the Tiles and configuration window if custom zoom levels have been specified for a tile.
+* Display asterisk next to each tile zoom level number in the Tiles and configuration window if custom zoom levels have been specified.
 * Includes Windows Python dependency wheel files for gdal and scikit-fmm.
 * Update and pin requirements to latest working versions.
 * Adds a bash script to automate the setup process for those that prefer not to use the packaged version.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This is a forked version of [Ortho4XP](https://github.com/oscarpilote/Ortho4XP) 
 
 The specific changes in this forked version:
 * Code changes to enable using [PyInstaller](https://pyinstaller.org/en/stable/) to bundle Ortho4XP and its dependencies into a single package.
-* Add the ability to set an alternate custom_overlay_src directory to resolve an issue for some users. The default X-Plane scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` and `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found if its a location where the .dsf files are located in the second directory.
+* Add the ability to set an alternate `custom_overlay_src` directory to resolve an issue for some users. The default X-Plane scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` and `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found if its a location where the .dsf files are located in the second directory.
 * Saves custom_dem and fill_nodata to global configuration.
+* Display asterik next to zoom level number in the Tiles and configuration window if custom zoom levels have been specified for a tile.
 * Includes Windows Python dependency wheel files for gdal and scikit-fmm.
 * Update and pin requirements to latest working versions.
 * Adds a bash script to automate the setup process for those that prefer not to use the packaged version.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The specific changes in this forked version:
 * Add the ability to set an alternate `custom_overlay_src` directory to resolve an issue for some users. The default X-Plane scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` and `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found if its a location where the .dsf files are located in the second directory.
 * Saves custom_dem and fill_nodata to global configuration.
 * Display asterisk next to each tile zoom level number in the Tiles and configuration window if custom zoom levels have been specified.
+* If one-click symlink feature is used, added removal of symlink when "Erase cached data" "Tile (whole)" option is used.
+* Add console feedback when using "Erase cached data" options.
+* Fix minor code typos as they are identified.
 * Includes Windows Python dependency wheel files for gdal and scikit-fmm.
 * Update and pin requirements to latest working versions.
 * Adds a bash script to automate the setup process for those that prefer not to use the packaged version.

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -19,7 +19,7 @@ pip install Utils\win\scikit_fmm-2024.5.29-cp312-cp312-win_amd64.whl
 echo:
 
 echo Installing remaining Python dependencies
-pip install -r requirements_win.txt
+pip install -r requirements.txt
 echo:
 
 echo Ortho4XP setup complete!

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ requests==2.32.3
 Rtree==1.2.0
 shapely==2.0.4
 scikit-fmm==2024.5.29
-gdal==3.9.0
+gdal==3.9.0; platform_system == 'Darwin'
+gdal==3.8.4; platform_system == 'Windows'

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -1,7 +1,0 @@
-numpy==1.26.4
-pillow==10.3.0
-pyproj==3.6.1
-requests==2.32.3
-Rtree==1.2.0
-shapely==2.0.4
-scikit-fmm==2024.5.29

--- a/src/O4_GUI_Utils.py
+++ b/src/O4_GUI_Utils.py
@@ -1460,11 +1460,14 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
                                 found_config = False
                         if found_config:
                             prov = zl = ""
+                            zone_list_exists = False
                             for line in tmpf.readlines():
                                 if line[:15] == "default_website":
                                     prov = line.strip().split("=")[1][:4]
                                 elif line[:10] == "default_zl":
                                     zl = int(line.strip().split("=")[1])
+                                elif line[:9] == "zone_list" and len(line[10:]) > 3:
+                                    zone_list_exists = True
                                     break
                             tmpf.close()
                             if not prov:
@@ -1473,6 +1476,8 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
                                 color = dico_color[zl]
                             else:
                                 zl = "?"
+                            if zone_list_exists:
+                                zl = str(zl) + "*"
                             content = prov + "\n" + str(zl)
                         else:
                             content = "?"

--- a/src/O4_GUI_Utils.py
+++ b/src/O4_GUI_Utils.py
@@ -1374,6 +1374,100 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
         self.threaded_preview()
         return
 
+    def add_symlink(self, lat: int, lon: int) -> None:
+        """Add symlink to custom_scenery_dir."""
+        if not self.grouped:
+            link = os.path.join(
+                CFG.custom_scenery_dir,
+                "zOrtho4XP_" + FNAMES.short_latlon(lat, lon),
+            )
+            target = os.path.realpath(
+                os.path.join(self.working_dir, self.dico_tiles_done[(lat, lon)][-1])
+            )
+        elif self.grouped:
+            link = os.path.join(
+                CFG.custom_scenery_dir,
+                "zOrtho4XP_" + os.path.basename(self.working_dir),
+            )
+            target = os.path.realpath(self.working_dir)
+        if ("dar" in sys.platform) or ("win" not in sys.platform):
+            # Mac and Linux
+            os.system("ln -s " + ' "' + target + '" "' + link + '"')
+        else:
+            os.system('MKLINK /J "' + link + '" "' + target + '"')
+        if not self.grouped:
+            if not OsX:
+                self.canvas.itemconfig(
+                    self.dico_tiles_done[(lat, lon)][0], stipple="gray50"
+                )
+            else:
+                self.canvas.itemconfig(
+                    self.dico_tiles_done[(lat, lon)][1],
+                    font=("Helvetica", "12", "bold underline"),
+                )
+        else:
+            for lat0, lon0 in self.dico_tiles_done:
+                if not OsX:
+                    self.canvas.itemconfig(
+                        self.dico_tiles_done[(lat0, lon0)][0], stipple="gray50"
+                    )
+                else:
+                    self.canvas.itemconfig(
+                        self.dico_tiles_done[(lat, lon)][1],
+                        font=("Helvetica", "12", "bold underline"),
+                    )
+
+    def remove_symlink(self, lat: int, lon: int) -> None:
+        """Remove symlink from custom_scenery_dir."""
+        if not self.grouped:
+            link = os.path.join(
+                CFG.custom_scenery_dir,
+                "zOrtho4XP_" + FNAMES.short_latlon(lat, lon),
+            )
+            target = os.path.realpath(
+                os.path.join(self.working_dir, self.dico_tiles_done[(lat, lon)][-1])
+            )
+            if os.path.isdir(link) and os.path.samefile(os.path.realpath(link), target):
+                os.remove(link)
+                if not OsX:
+                    self.canvas.itemconfig(
+                        self.dico_tiles_done[(lat, lon)][0], stipple="gray12"
+                    )
+                else:
+                    self.canvas.itemconfig(
+                        self.dico_tiles_done[(lat, lon)][1],
+                        font=("Helvetica", "12", "normal"),
+                    )
+                return True
+
+        elif self.grouped:
+            link = os.path.join(
+                CFG.custom_scenery_dir,
+                "zOrtho4XP_" + os.path.basename(self.working_dir),
+            )
+            target = os.path.realpath(self.working_dir)
+            if os.path.isdir(link) and os.path.samefile(
+                os.path.realpath(link), os.path.realpath(self.working_dir)
+            ):
+                os.remove(link)
+                for (lat, lon) in self.dico_tiles_done:
+                    if not OsX:
+                        self.canvas.itemconfig(
+                            self.dico_tiles_done[(lat, lon)][0],
+                            stipple="gray12",
+                        )
+                    else:
+                        self.canvas.itemconfig(
+                            self.dico_tiles_done[(lat, lon)][1],
+                            font=("Helvetica", "12", "normal"),
+                        )
+                return True
+        # in case this was a broken link
+        try:
+            os.remove(link)
+        except:
+            pass
+
     def set_working_dir(self):
         self.custom_build_dir = self.parent.custom_build_dir.get()
         self.grouped = (
@@ -1625,17 +1719,32 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
             )
         return
 
-    def trash(self):
+    def trash(self) -> None:
+        """Delete data for selected/active tile."""
         if self.v_["OSM data"].get():
             try:
                 shutil.rmtree(FNAMES.osm_dir(self.active_lat, self.active_lon))
             except Exception as e:
                 UI.vprint(3, e)
+            finally:
+                UI.vprint(
+                    0,
+                    "OSM data removed for tile at "
+                    + str(self.active_lat)
+                    + str(self.active_lon),
+                )
         if self.v_["Mask data"].get():
             try:
                 shutil.rmtree(FNAMES.mask_dir(self.active_lat, self.active_lon))
             except Exception as e:
                 UI.vprint(3, e)
+            finally:
+                UI.vprint(
+                    0,
+                    "Mask data removed for tile at "
+                    + str(self.active_lat)
+                    + str(self.active_lon),
+                )
         if self.v_["Jpeg imagery"].get():
             try:
                 shutil.rmtree(
@@ -1646,8 +1755,16 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
                 )
             except Exception as e:
                 UI.vprint(3, e)
+            finally:
+                UI.vprint(
+                    0,
+                    "Jpeg imagery removed for tile at "
+                    + str(self.active_lat)
+                    + str(self.active_lon),
+                )
         if self.v_["Tile (whole)"].get() and not self.grouped:
             try:
+                self.remove_symlink(self.active_lat, self.active_lon)
                 shutil.rmtree(
                     FNAMES.build_dir(
                         self.active_lat, self.active_lon, self.custom_build_dir
@@ -1655,10 +1772,15 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
                 )
             except Exception as e:
                 UI.vprint(3, e)
+            finally:
+                UI.vprint(
+                    0,
+                    "Tile (whole) removed for tile at "
+                    + str(self.active_lat)
+                    + str(self.active_lon),
+                )
             if (self.active_lat, self.active_lon) in self.dico_tiles_done:
-                for objid in self.dico_tiles_done[
-                    (self.active_lat, self.active_lon)
-                ][:2]:
+                for objid in self.dico_tiles_done[(self.active_lat, self.active_lon)][:2]:
                     self.canvas.delete(objid)
                 del self.dico_tiles_done[(self.active_lat, self.active_lon)]
         if self.v_["Tile (textures)"].get() and not self.grouped:
@@ -1675,6 +1797,13 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
                 )
             except Exception as e:
                 UI.vprint(3, e)
+            finally:
+                UI.vprint(
+                    0,
+                    "Tile (textures) removed for tile at "
+                    + str(self.active_lat)
+                    + str(self.active_lon),
+                )
         return
 
     def select_tile(self, event):
@@ -1697,92 +1826,16 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
         self.parent.lon.set(lon)
         return
 
-    def toggle_to_custom(self, event):
+    def toggle_to_custom(self, event: tk.Event) -> None:
+        """Create or delete symlink to custom_scenery_dir on user action."""
         x = self.canvas.canvasx(event.x)
         y = self.canvas.canvasy(event.y)
         (lat, lon) = [floor(t) for t in GEO.pix_to_wgs84(x, y, self.earthzl)]
         if (lat, lon) not in self.dico_tiles_done:
             return
-        if not self.grouped:
-            link = os.path.join(
-                CFG.custom_scenery_dir,
-                "zOrtho4XP_" + FNAMES.short_latlon(lat, lon),
-            )
-            # target=os.path.realpath(os.path.join(self.working_dir,
-            # 'zOrtho4XP_'+FNAMES.short_latlon(lat,lon)))
-            target = os.path.realpath(
-                os.path.join(
-                    self.working_dir, self.dico_tiles_done[(lat, lon)][-1]
-                )
-            )
-            if os.path.isdir(link) and os.path.samefile(
-                os.path.realpath(link), target
-            ):
-                os.remove(link)
-                if not OsX:
-                    self.canvas.itemconfig(
-                        self.dico_tiles_done[(lat, lon)][0], stipple="gray12"
-                    )
-                else:
-                    self.canvas.itemconfig(
-                        self.dico_tiles_done[(lat, lon)][1],
-                        font=("Helvetica", "12", "normal"),
-                    )
-                return
-        elif self.grouped:
-            link = os.path.join(
-                CFG.custom_scenery_dir,
-                "zOrtho4XP_" + os.path.basename(self.working_dir),
-            )
-            target = os.path.realpath(self.working_dir)
-            if os.path.isdir(link) and os.path.samefile(
-                os.path.realpath(link), os.path.realpath(self.working_dir)
-            ):
-                os.remove(link)
-                for (lat0, lon0) in self.dico_tiles_done:
-                    if not OsX:
-                        self.canvas.itemconfig(
-                            self.dico_tiles_done[(lat, lon)][0],
-                            stipple="gray12",
-                        )
-                    else:
-                        self.canvas.itemconfig(
-                            self.dico_tiles_done[(lat, lon)][1],
-                            font=("Helvetica", "12", "normal"),
-                        )
-                return
-        # in case this was a broken link
-        try:
-            os.remove(link)
-        except:
-            pass
-        if ("dar" in sys.platform) or (
-            "win" not in sys.platform
-        ):  # Mac and Linux
-            os.system("ln -s " + ' "' + target + '" "' + link + '"')
-        else:
-            os.system('MKLINK /J "' + link + '" "' + target + '"')
-        if not self.grouped:
-            if not OsX:
-                self.canvas.itemconfig(
-                    self.dico_tiles_done[(lat, lon)][0], stipple="gray50"
-                )
-            else:
-                self.canvas.itemconfig(
-                    self.dico_tiles_done[(lat, lon)][1],
-                    font=("Helvetica", "12", "bold underline"),
-                )
-        else:
-            for (lat0, lon0) in self.dico_tiles_done:
-                if not OsX:
-                    self.canvas.itemconfig(
-                        self.dico_tiles_done[(lat0, lon0)][0], stipple="gray50"
-                    )
-                else:
-                    self.canvas.itemconfig(
-                        self.dico_tiles_done[(lat, lon)][1],
-                        font=("Helvetica", "12", "bold underline"),
-                    )
+        if self.remove_symlink(lat, lon):
+            return
+        self.add_symlink(lat, lon)
         return
 
     def add_tile(self, event):


### PR DESCRIPTION
The following changes are made with this pull request:

**Features:**
- Added an asterisk next to the zoom level number for each tile in the Tiles and management window if custom zoom levels have been specified for a tile (screenshot below). This allows a user to quickly see which tiles have custom zoom levels without having to open the Preview / Custom zoomlevels window for each tile to check. In the example screenshot below, two tiles have been built and the bottom tile has custom zoom levels specified.
- Add console feedback when using "Erase cached data" options. Slightly redundant for the "Tile (whole)" option since the tile outline disappears but I added it for consistency when the other options are used since you get no feedback with those.

**Bug Fixes:**
- If one-click symlink feature is used, added removal of symlink when "Erase cached data" "Tile (whole)" option is used. Previously, this would broken symlinks. As a part of this, refactored the code and created two new methods `add_symlink` and `remove_symlink` in the `Ortho4XP_Earth_Preview` class.
- Fixed [typo](https://github.com/shred86/Ortho4XP/blob/939f1ce8d4a0fb8f3c07b5f64baa687b300887c9/src/O4_GUI_Utils.py#L1597) in variable naming.

![zoom-level-asterik](https://github.com/shred86/Ortho4XP/assets/32663154/2716399e-b530-45ed-a08d-252aad71f87a)

@w8sl I think I saw you mention on the official repo that the progressive_zl branch had some similar feature. I'd be curious to get your feedback if this is something similar.
