### PR TITLE
Fix issue with zone_list saving in tile configuration, save on exit and versioning

### DIFF
--- a/Ortho4XP.py
+++ b/Ortho4XP.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     IMG.initialize_combined_providers_dict()
     if len(sys.argv)==1: # switch to the graphical interface
         Ortho4XP = GUI.Ortho4XP_GUI()
-
+        Ortho4XP.protocol("WM_DELETE_WINDOW", Ortho4XP.exit_prg)
         Ortho4XP.mainloop()	    
         print("Bon vol!")
     else: # sequel is only concerned with command line 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The specific changes in this forked version:
 * Display asterisk next to each tile zoom level number in the Tiles and configuration window if custom zoom levels have been specified.
 * If one-click symlink feature is used, added removal of symlink when "Erase cached data" "Tile (whole)" option is used.
 * Add console feedback when using "Erase cached data" options.
+* Fix zones being saved to tile configuration that were outside of the tile location.
 * Fix minor code typos as they are identified.
 * Includes Windows Python dependency wheel files for gdal and scikit-fmm.
 * Update and pin requirements to latest working versions.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a forked version of [Ortho4XP](https://github.com/oscarpilote/Ortho4XP) 
 The specific changes in this forked version:
 * Code changes to enable using [PyInstaller](https://pyinstaller.org/en/stable/) to bundle Ortho4XP and its dependencies into a single package.
 * Add the ability to set an alternate `custom_overlay_src` directory to resolve an issue for some users. The default X-Plane scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` and `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found if its a location where the .dsf files are located in the second directory.
+* Automatically saves the same data (active tile, default provider, default zoom level and base folder) that the power button icon does when you close the application using the operating system close button.
 * Saves custom_dem and fill_nodata to global configuration.
 * Display asterisk next to each tile zoom level number in the Tiles and configuration window if custom zoom levels have been specified.
 * If one-click symlink feature is used, added removal of symlink when "Erase cached data" "Tile (whole)" option is used.

--- a/src/O4_Config_Utils.py
+++ b/src/O4_Config_Utils.py
@@ -20,32 +20,21 @@ cfg_vars = {
         "type": int,
         "default": 1,
         "values": (0, 1, 2, 3),
-        "hint": 
-"Verbosity determines the amount of information about the whole process which \
-is printed on screen.  Critical errors, if any, are reported in all states as \
-well as in the Log. Values above 1 are probably only useful for for debug \
-purposes.",
+        "hint": "Verbosity determines the amount of information about the whole process which is printed on screen.  Critical errors, if any, are reported in all states as well as in the Log. Values above 1 are probably only useful for for debug purposes.",
     },
     "cleaning_level": {
         "module": "UI",
         "type": int,
         "default": 1,
         "values": (0, 1, 2, 3),
-        "hint": 
-"Determines which temporary files are removed. Level 3 erases everything \
-except the config and what is needed for X-Plane; Level 2 erases everything \
-except what is needed to redo the current step only; Level 1 allows you to \
-redo any prior step; Level 0 keeps every single file.",
+        "hint": "Determines which temporary files are removed. Level 3 erases everything except the config and what is needed for X-Plane; Level 2 erases everything except what is needed to redo the current step only; Level 1 allows you to redo any prior step; Level 0 keeps every single file.",
     },
     "overpass_server_choice": {
         "module": "OSM",
         "type": str,
         "default": "random",
         "values": ["random"] + sorted(OSM.overpass_servers.keys()),
-        "hint": 
-"The (country) of the Overpass OSM server used to grab vector data. It can be \
-modified on the fly (as all _Application_ variables) in case of problem with \
-a particular server.",
+        "hint": "The (country) of the Overpass OSM server used to grab vector data. It can be modified on the fly (as all _Application_ variables) in case of problem with a particular server.",
     },
     "skip_downloads": {
         "module": "TILE",
@@ -112,12 +101,6 @@ a particular server.",
         "type": str,
         "default": "",
         "hint": "The directory containing the sceneries with the overlays you would like to extract. You need to select the level of directory just _ABOVE_ Earth nav data.",
-    },
-    "custom_overlay_src_alternate": {
-        "module": "OVL",
-        "type": str,
-        "default": "",
-        "hint": "If sceneries with overlays are not found in custom_overlay_src, set an alternate directory to search.",
     },
     # Vector
     "apt_smoothing_pix": {
@@ -255,10 +238,7 @@ a particular server.",
     "distance_masks_too": {
         "type": bool,
         "default": False,
-        "hint": "This will additionally build distance to coastline masks that \
-are used in Step 3 in order to improve the bathymetric profile (otherwise too \
-low res) and avoid steep walls close to piers or rocks. Masks_zl should not be \
-too low to grab these details.",
+        "hint": "This will additionally build distance to coastline masks that are used in Step 3 in order to improve the bathymetric profile (otherwise too low res) and avoid steep walls close to piers or rocks. Masks_zl should not be too low to grab these details.",
     },
     "masks_use_DEM_too": {
         "type": bool,
@@ -297,22 +277,22 @@ too low to grab these details.",
         "hint": 'For layers of type "mask" in combined providers imageries, determines the extent (in meters) of the blur radius applied. This allows to smoothen some sea imageries where the wave or reflection pattern was too much present.',
     },
     "water_tech": {
-            "type": str,
-            "default": "XP11 + bathy",
-            "values" : ("XP12", "XP11 + bathy"),
-            "hint" : "Water tech type. XP12 uses a new (partly in construction) rendering tech, XP11 + bathy uses a more traditionnal blend. Both allows for 3D water."
+        "type": str,
+        "default": "XP11 + bathy",
+        "values": ("XP12", "XP11 + bathy"),
+        "hint": "Water tech type. XP12 uses a new (partly in construction) rendering tech, XP11 + bathy uses a more traditionnal blend. Both allows for 3D water.",
     },
-    #"add_low_res_sea_ovl": {
+    # "add_low_res_sea_ovl": {
     #    "type": bool,
     #    "default": False,
     #    "hint": "Will add an extra texture layer over the sea (with constant alpha channel given by ratio_water as for inland water), based on a low resolution imagery with global coverage. Masks with their full resolution imagery are still being used when present, the final render is a composite of both. The default imagery with code SEA can be changed as any other imagery defined in the Providers directory, it needs to have a max_zl defined and is used at its max_zl.",
-    #},
-    #"experimental_water": {
+    # },
+    # "experimental_water": {
     #    "type": int,
     #    "default": 0,
     #    "values": (0, 1, 2, 3),
     #    "hint": 'If non zero, replaces X-Plane water by a custom normal map over low res ortho-imagery (requires XP11 but turns water rendering more XP10 alike). The value 0 corresponds to legacy X-Plane water, 1 replaces it for inland water only, 2 over sea water only, and 3 over both. Values 2 and 3 should always be used in combination with "imprint_masks_to_dds".\n\nThis experimental feature has two strong downsides: 1) the waves are static rather dynamical (would require a plugin to update the normal_map as X-Plane does) and 2) the wave height is no longer weather dependent. On the other hand, waves might have less repetitive patterns and some blinking in water reflections might be improved too; users are welcome to improve the provided water_normal_map.dds (Gimp can be used to edit the mipmaps individually).',
-    #},
+    # },
     "ratio_water": {
         "type": float,
         "default": 0.25,
@@ -321,12 +301,12 @@ too low to grab these details.",
     "ratio_bathy": {
         "type": float,
         "default": 1.0,
-        "hint": 'Bathymetry multiplier for near shore vertices. In the range [0,1].'
+        "hint": "Bathymetry multiplier for near shore vertices. In the range [0,1].",
     },
     "normal_map_strength": {
         "type": float,
         "default": 1,
-        "hint": 'Orthophotos by essence already contain the part of the shading burned in (here by shading we mean the amount of reflected light in the camera direction as a function of the terrain slope, not the shadows). This option allows to tweak the normal coordinates of the mesh in the DSF to avoid "overshading", but it has side effects on the way X-Plane computes scenery shadows. Used to be 0.3 by default in earlier versions, the default is now 1 which means exact normals.},      ',
+        "hint": 'Orthophotos by essence already contain the part of the shading burned in (here by shading we mean the amount of reflected light in the camera direction as a function of the terrain slope, not the shadows). This option allows to tweak the normal coordinates of the mesh in the DSF to avoid "overshading", but it has side effects on the way X-Plane computes scenery shadows. Used to be 0.3 by default in earlier versions, the default is now 1 which means exact normals.',
     },
     "terrain_casts_shadows": {
         "type": bool,
@@ -348,7 +328,7 @@ too low to grab these details.",
     "custom_dem": {
         "type": str,
         "default": "",
-        "hint": "Path to an elevation data file to be used instead of the default Viewfinderpanoramas.org ones (J. de Ferranti). The raster must be in geopgraphical coordinates (EPSG:4326) but the extent need not match the tile boundary (requires Gdal). Regions of the tile that are not covered by the raster are mapped to zero altitude (can be useful for high resolution data over islands in particular).     ",
+        "hint": "Path to an elevation data file to be used instead of the default Viewfinderpanoramas.org ones (J. de Ferranti). The raster must be in geopgraphical coordinates (EPSG:4326) but the extent need not match the tile boundary (requires Gdal). Regions of the tile that are not covered by the raster are mapped to zero altitude (can be useful for high resolution data over islands in particular).",
     },
     "fill_nodata": {
         "type": bool,
@@ -372,10 +352,9 @@ list_app_vars = [
     "ovl_exclude_net",
     "custom_scenery_dir",
     "custom_overlay_src",
-    "custom_overlay_src_alternate"
 ]
-gui_app_vars_short = list_app_vars[:-3]
-gui_app_vars_long = list_app_vars[-3:]
+gui_app_vars_short = list_app_vars[:-2]
+gui_app_vars_long = list_app_vars[-2:]
 
 list_vector_vars = [
     "apt_smoothing_pix",
@@ -420,8 +399,8 @@ list_dsf_vars = [
     "ratio_water",
     "overlay_lod",
     "sea_texture_blur",
-    #"add_low_res_sea_ovl",
-    #"experimental_water",
+    # "add_low_res_sea_ovl",
+    # "experimental_water",
     "normal_map_strength",
     "terrain_casts_shadows",
     "use_decal_on_terrain",
@@ -437,12 +416,7 @@ list_tile_vars = (
 )
 
 list_global_cfg = (
-    list_app_vars
-    + list_vector_vars
-    + list_mesh_vars
-    + list_mask_vars
-    + list_dsf_vars
-    + list_other_vars
+    list_app_vars + list_vector_vars + list_mesh_vars + list_mask_vars + list_dsf_vars
 )
 
 ################################################################################
@@ -1025,6 +999,7 @@ class Ortho4XP_Config(tk.Toplevel):
                     pass
         if not self.v_["zone_list"].get():
             self.v_["zone_list"].set(str(zone_list))
+        UI.vprint(0, f"Configuration loaded for tile at {lat} {lon}")
         f.close()
 
     def write_tile_cfg(self):
@@ -1047,10 +1022,24 @@ class Ortho4XP_Config(tk.Toplevel):
         except:
             self.popup("ERROR", "Cannot write into " + str(build_dir))
             return 0
-        self.v_["zone_list"].set(str(eval("zone_list")))
+        
+        self.v_["zone_list"].set(str(eval("zone_list"))) # convert tk.StringVar to str
+        zone_list = eval(self.v_["zone_list"].get()) # convert str to list
+        tile_zones = []
+
+        for zone in zone_list:
+            _zone_list = [int(coord) for coord in zone[0]]
+            _zone_list = set(_zone_list)
+            if lat in _zone_list and lon+1 in _zone_list:
+                tile_zones.append(zone)
+
         for var in list_tile_vars:
-            f.write(var + "=" + self.v_[var].get() + "\n")
+            if var == "zone_list":
+                f.write(var + "=" + str(tile_zones) + "\n")
+            else:
+                f.write(var + "=" + self.v_[var].get() + "\n")
         f.close()
+        UI.vprint(1, f"Configuration saved for tile at {lat} {lon}")
         return
 
     def load_global_cfg(self):
@@ -1075,6 +1064,7 @@ class Ortho4XP_Config(tk.Toplevel):
             except:
                 pass
         f.close()
+        UI.vprint(1, "Global configuration loaded.")
         return
 
     def write_global_cfg(self):
@@ -1087,6 +1077,7 @@ class Ortho4XP_Config(tk.Toplevel):
             for var in list_global_cfg:
                 f.write(var + "=" + self.v_[var].get() + "\n")
             f.close()
+            UI.vprint(1, "Global configuration saved.")
         except:
             UI.lvprint(1, "Could not write global config.")
         return
@@ -1135,6 +1126,7 @@ class Ortho4XP_Config(tk.Toplevel):
                 + "\n* ".join(errors)
             )
             self.popup("ERROR", error_text)
+        UI.vprint(1, "Configuration settings applied.")
 
     def popup(self, header, input_text):
         self.popupwindow = tk.Toplevel()

--- a/src/O4_Config_Utils.py
+++ b/src/O4_Config_Utils.py
@@ -102,6 +102,12 @@ cfg_vars = {
         "default": "",
         "hint": "The directory containing the sceneries with the overlays you would like to extract. You need to select the level of directory just _ABOVE_ Earth nav data.",
     },
+    "custom_overlay_src_alternate": {
+        "module": "OVL",
+        "type": str,
+        "default": "",
+        "hint": "If sceneries with overlays are not found in custom_overlay_src, set an alternate directory to search.",
+    },
     # Vector
     "apt_smoothing_pix": {
         "type": int,
@@ -352,9 +358,10 @@ list_app_vars = [
     "ovl_exclude_net",
     "custom_scenery_dir",
     "custom_overlay_src",
+    "custom_overlay_src_alternate",
 ]
-gui_app_vars_short = list_app_vars[:-2]
-gui_app_vars_long = list_app_vars[-2:]
+gui_app_vars_short = list_app_vars[:-3]
+gui_app_vars_long = list_app_vars[-3:]
 
 list_vector_vars = [
     "apt_smoothing_pix",

--- a/src/O4_Version.py
+++ b/src/O4_Version.py
@@ -1,1 +1,1 @@
-version='1.40'
+version='1.40.01'


### PR DESCRIPTION
Changes:
- Fixes an issue where zones outside of a tiles area were being saved to its configuration. Also adds some console feedback when configuration buttons are pressed. More [details here](https://github.com/oscarpilote/Ortho4XP/pull/266) on the PR I made on the official fork.
- Adds a feature that will call `exit_prg` when Ortho4XP is closed using the operating system's close button. Previously, `exit_prg` was only called when the power button icon was used, which saves your current active tile coordinates, default/base provider, zoom level and base directory. This will now happen regardless of which method you use to close the app. This makes the power button icon redundant and maybe can be removed in the future.
- Adds versioning since I plan on continuing to push updates and allows users to identify which version they're on. The plan is to match the official version 1.4, but we will just append a minor revision number starting with .01, so 1.4.01.

