### PR TITLE
Fix EOX Provider.

### DIFF
--- a/Providers/Global/EOX2.lay
+++ b/Providers/Global/EOX2.lay
@@ -1,5 +1,0 @@
-request_type=tms
-grid_type=webmercator
-url_template=https://{switch:a,b,c,d}.s2maps-tiles.eu/wmts/?layer=s2cloudless-2018_3857&style=default&tilematrixset=GoogleMapsCompatible&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={zoom}&TileCol={x}&TileRow={y}
-max_zl=14
-imagery_dir=grouped

--- a/Providers/Global/EOX23.lay
+++ b/Providers/Global/EOX23.lay
@@ -1,0 +1,5 @@
+request_type=tms
+grid_type=webmercator
+url_template=https://{switch:a,b,c,d}.tiles.maps.eox.at/wmts/?layer=s2cloudless-2023_3857&style=default&tilematrixset=GoogleMapsCompatible&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={zoom}&TileCol={x}&TileRow={y}
+max_zl=14
+imagery_dir=grouped


### PR DESCRIPTION
I've updated the EOX2.lay.

The URL to acces EOX has changed to 
"https://{switch:a,b,c,d}.**tiles.maps.eox.at**/wmts/?layer=s2cloudless-2023_3857&style=default&tilematrixset=GoogleMapsCompatible&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={zoom}&TileCol={x}&TileRow={y}"

the old one is no longer working.
 I've also renamed it to EOX23.lay as it uses now 2023 Data.

Grettings TO-GA from the Org Forum