### PR TITLE
Fix windows path handling

### DIFF
--- a/src/O4_Config_Utils.py
+++ b/src/O4_Config_Utils.py
@@ -144,7 +144,7 @@ class Tile:
         self.custom_build_dir = custom_build_dir
         self.grouped = (
             True
-            if (custom_build_dir and custom_build_dir[-1] != "/")
+            if (custom_build_dir and (custom_build_dir[-1] != "/" or custom_build_dir[-1] != "\\"))
             else False
         )
         self.build_dir = FNAMES.build_dir(lat, lon, custom_build_dir)

--- a/src/O4_File_Names.py
+++ b/src/O4_File_Names.py
@@ -73,7 +73,7 @@ def tile_dir(lat, lon):
 def build_dir(lat, lon, custom_build_dir):
     if not custom_build_dir:
         return os.path.join(Tile_dir, tile_dir(lat, lon))
-    elif custom_build_dir[-1] == "/":
+    elif custom_build_dir[-1] == "/" or custom_build_dir[-1] == "\\":
         return os.path.join(custom_build_dir[:-1], tile_dir(lat, lon))
     else:
         return custom_build_dir

--- a/src/O4_GUI_Utils.py
+++ b/src/O4_GUI_Utils.py
@@ -1692,7 +1692,7 @@ class Ortho4XP_Earth_Preview(tk.Toplevel):
     def set_working_dir(self):
         self.custom_build_dir = self.parent.custom_build_dir.get()
         self.grouped = (
-            self.custom_build_dir and self.custom_build_dir[-1] != "/"
+            self.custom_build_dir and (self.custom_build_dir[-1] != "/" or self.custom_build_dir[-1] != "\\")
         )
         self.working_dir = (
             self.custom_build_dir if self.custom_build_dir else FNAMES.Tile_dir


### PR DESCRIPTION
feat: add support for Windows path delimiters

This commit enhances the handling of file paths across different operating systems by supporting both forward slashes and backslashes as path delimiters. It improves the path handling in build_dir, set_working_dir, and related configuration utilities.

The changes ensure that the software can operate smoothly on Windows platforms without path issues, thus broadening its compatibility.

Closes #master
```