### PR TITLE
feat: add max_download_slots configuration with dynamic worker setup

### DIFF
--- a/src/O4_Cfg_Vars.py
+++ b/src/O4_Cfg_Vars.py
@@ -360,6 +360,7 @@ list_app_vars = [
     "overpass_server_choice",
     "skip_downloads",
     "skip_converts",
+    "max_download_slots",
     "max_convert_slots",
     "check_tms_response",
     "http_timeout",

--- a/src/O4_DSF_Utils.py
+++ b/src/O4_DSF_Utils.py
@@ -1044,8 +1044,6 @@ def build_dsf(tile, download_queue):
                 total_cross_pool += 1
                 textured_tris[0]["cross-pool"].extend(tri_p)
     
-    download_queue.put("quit")
-
     UI.vprint(1, "-> Encoding of the DSF file")
     UI.vprint(1, "     Final nbr of nodes: " + str(len_textured_nodes))
     UI.vprint(2, "     Final nbr of cross pool tris: " + str(total_cross_pool))


### PR DESCRIPTION
This commit introduces a new configuration parameter 'max_download_slots' in O4_Cfg_Vars.py, which allows users to specify the number of parallel threads for imagery downloads. The implementation dynamically adjusts the number of workers in O4_Tile_Utils.py based on this configuration, enhancing the download efficiency when network conditions permit higher concurrency. The commit simplifies the download_textures function by replacing static worker management with a flexible and error-handling rich implementation using the new max_download_slots setting.

Refactored the download queue processing to utilize a thread-based management approach, improving error handling and retry logic. This change aims to make the download process more robust and maintainable.