### PR TITLE
Fix tile.dem=None crash when Overpass airport query fails

### DIFF
--- a/src/O4_Vector_Map.py
+++ b/src/O4_Vector_Map.py
@@ -49,6 +49,21 @@ def build_poly_file(tile):
         UI.exit_message_and_bottom_line()
         return 0
 
+    # Load DEM up front so every include_* helper below can rely on
+    # tile.dem being valid even if the OSM airport query later fails.
+    # The DEM has no data dependency on OSM; previously this load was
+    # nested inside include_airports after the OSM query, so an Overpass
+    # timeout left tile.dem = None and crashed include_water with
+    # AttributeError: 'NoneType' object has no attribute 'alt_vec'.
+    UI.vprint(1, "   Loading elevation data.")
+    tile.dem = DEM.DEM(
+        tile.lat,
+        tile.lon,
+        tile.custom_dem,
+        tile.fill_nodata or "to zero",
+        info_only=False,
+    )
+
     # Airports
     (apt_array, apt_area) = include_airports(vector_map, tile)
     UI.vprint(
@@ -203,14 +218,7 @@ def include_airports(vector_map, tile):
     APT.build_taxiway_areas(tile, airport_layer, dico_airports)
     APT.update_airport_boundaries(tile, dico_airports)
     APT.list_airports_and_runways(dico_airports)
-    UI.vprint(1, "   Loading elevation data and smoothing it over airports.")
-    tile.dem = DEM.DEM(
-        tile.lat,
-        tile.lon,
-        tile.custom_dem,
-        tile.fill_nodata or "to zero",
-        info_only=False,
-    )
+    UI.vprint(1, "   Smoothing elevation data over airports.")
     APT.smooth_raster_over_airports(tile, dico_airports)
     (patches_area, patches_list) = include_patches(vector_map, tile)
     runway_taxiway_apron_area = APT.encode_runways_taxiways_and_aprons(


### PR DESCRIPTION
Closes #89.

### What this changes

Move `tile.dem = DEM.DEM(...)` from inside `include_airports` to the top of `build_poly_file`. The DEM has no data dependency on OSM data, so loading it before any `include_*` helper guarantees `tile.dem` is valid for the rest of the pipeline regardless of OSM availability.

The log line in `include_airports` is also updated to reflect what the function does now (smoothing only, since loading moved).

### Why

When the Overpass airport query at the start of `include_airports` fails (timeout, 5xx), the function early-returns at `O4_Vector_Map.py:195` *before* the DEM load at line 207. `tile.dem` stays at its initial `None` (set in `O4_Tile_Utils.py:349`), and the next `include_*` helper that touches `tile.dem.alt_vec` crashes the worker thread:

```
File "O4_Vector_Map.py", line 84, in build_poly_file
File "O4_Vector_Map.py", line 560, in include_water
AttributeError: 'NoneType' object has no attribute 'alt_vec'
```

The crash typically lands in `include_water` because `include_sea` and `include_roads` short-circuit on tiles without sea or road data. Failure rate scales with OSM density (Overpass timeouts), so dense regions like India and China are disproportionately affected. See #89 for the full call-chain analysis.

### Verification

Built a frozen Linux binary from this branch via PyInstaller and ran multiple previously-failing tiles successfully, including `+26+080` (central India) which was the original repro. No new failure modes observed.

### Notes

- `APT.smooth_raster_over_airports` still runs at its existing call site inside `include_airports`. Order of DEM load → airport smoothing is preserved (DEM now loaded earlier rather than later).
- A defensive follow-up to consider: have `OSM.OSM_queries_to_OSM_layer` failures bubble up via `UI.red_flag` so `build_poly_file` short-circuits cleanly instead of partially executing. That's a larger change and out of scope here; this PR fixes the immediate crash class.